### PR TITLE
Make MCJE on X11 happy (Fix `GLFW_PLATFORM_ERROR` on x11)

### DIFF
--- a/src/main/java/org/lwjgl/opengl/Display.java
+++ b/src/main/java/org/lwjgl/opengl/Display.java
@@ -159,9 +159,9 @@ public final class Display {
 	public static void create(@NotNull PixelFormat pixelFormat) throws LWJGLException {
 		// Setup an error callback. The default implementation
 		GLFWErrorCallback.createPrint(System.err).set();
-		if (GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND)) {
-			GLFW.glfwInitHint(GLFW.GLFW_PLATFORM, GLFW.GLFW_PLATFORM_WAYLAND); // enable wayland backend if supported
-		}
+//		if (GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND)) {
+//			 GLFW.glfwInitHint(GLFW.GLFW_PLATFORM, GLFW.GLFW_PLATFORM_WAYLAND); // enable wayland backend if supported
+//		}
 		if (!GLFW.glfwInit()) {
 			throw new IllegalStateException("Unable to initialize GLFW");
 		} else {


### PR DESCRIPTION
- `GLFW.glfwPlatformSupported(GLFW.GLFW_PLATFORM_WAYLAND)` always returns true on LWJGL 3.3.4 causing `GLFW_PLATFORM_ERROR` on xorg
- And LWJGL 3.3.4 now automatically select wayland if available