### PR TITLE
fix stuff for macos

### DIFF
--- a/common/src/main/java/io/github/moehreag/legacylwjgl3/MacOSPreLaunch.java
+++ b/common/src/main/java/io/github/moehreag/legacylwjgl3/MacOSPreLaunch.java
@@ -1,0 +1,13 @@
+package io.github.moehreag.legacylwjgl3;
+
+import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
+
+public class MacOSPreLaunch implements PreLaunchEntrypoint {
+	@Override
+	public void onPreLaunch() {
+		if (System.getProperty("os.name").startsWith("Mac")) {
+			// prevent AWT from taking over the AppKit event loop from GLFW/SDL
+			System.setProperty("java.awt.headless", "true");
+		}
+	}
+}

--- a/src/main/java/io/github/moehreag/legacylwjgl3/MacOSPreLaunch.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/MacOSPreLaunch.java
@@ -1,11 +1,12 @@
 package io.github.moehreag.legacylwjgl3;
 
+import io.github.moehreag.legacylwjgl3.util.OS;
 import net.fabricmc.loader.api.entrypoint.PreLaunchEntrypoint;
 
 public class MacOSPreLaunch implements PreLaunchEntrypoint {
 	@Override
 	public void onPreLaunch() {
-		if (System.getProperty("os.name").startsWith("Mac")) {
+		if (OS.current() == OS.OSX) {
 			// prevent AWT from taking over the AppKit event loop from GLFW/SDL
 			System.setProperty("java.awt.headless", "true");
 		}

--- a/src/main/java/io/github/moehreag/legacylwjgl3/implementation/glfw/GLFWMouseImplementation.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/implementation/glfw/GLFWMouseImplementation.java
@@ -147,6 +147,6 @@ public class GLFWMouseImplementation implements MouseImplementation {
 
     @Override
     public boolean isInsideWindow() {
-        return this.isInsideWindow;
+        return grabbed || isInsideWindow;
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,6 +17,9 @@
   "icon": "assets/legacy-lwjgl3/icon.png",
   "environment": "client",
   "entrypoints": {
+	"preLaunch": [
+	  "io.github.moehreag.legacylwjgl3.MacOSPreLaunch"
+	],
     "client": [
 	    "io.github.moehreag.legacylwjgl3.LegacyLWJGL3"
     ]


### PR DESCRIPTION
1. on macos, glfw/sdl run on the macos app main thread (because `-XstartOnFirstThread` is set). then, during `glfwPollEvents`/`SDL_PollEvent`, AppKit executes the queued `AWTStarter`, which calls `NSApplication.run`, starting a nested event loop that never returns. setting `java.awt.headless=true` early on macos prevents this.
2. vanilla has this workaround on macos every frame:
```java
if (IS_MAC && focused && !Mouse.isInsideWindow()) {
    Mouse.setGrabbed(false);
    Mouse.setCursorPosition(center);
    Mouse.setGrabbed(true);
}
```
the legacy-lwjgl3 glfw mouse adapter incorrectly reports `false` for `Mouse.isInsideWindow` when the cursor is already grabbed. (this doesn't happen with sdl, since it queues `SDL_EVENT_WINDOW_MOUSE_ENTER` and `SDLDisplay.update` processes it before the vanilla workaround matters)