### PR TITLE
fix more annoying macos bugs

### DIFF
--- a/common/src/main/java/io/github/moehreag/legacylwjgl3/LegacyLWJGL3.java
+++ b/common/src/main/java/io/github/moehreag/legacylwjgl3/LegacyLWJGL3.java
@@ -23,4 +23,8 @@ public class LegacyLWJGL3 implements ClientModInitializer {
 	public static void setClipboard(String s) {
 		LegacyLWJGL3Internal.setClipboard(s);
 	}
+
+	public static void openLink(String s) {
+		LegacyLWJGL3Internal.openLink(s);
+	}
 }

--- a/common/src/main/java/io/github/moehreag/legacylwjgl3/implementation/LegacyLWJGL3Internal.java
+++ b/common/src/main/java/io/github/moehreag/legacylwjgl3/implementation/LegacyLWJGL3Internal.java
@@ -16,4 +16,8 @@ public final class LegacyLWJGL3Internal {
 	public static void setClipboard(String s) {
 		throw new UnsupportedOperationException("Implemented in Mixin");
 	}
+
+	public static void openLink(String s) {
+		throw new UnsupportedOperationException("Implemented in Mixin");
+	}
 }

--- a/src/main/java/io/github/moehreag/legacylwjgl3/Lwjgl3MixinPostProcessor.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/Lwjgl3MixinPostProcessor.java
@@ -42,7 +42,7 @@ public class Lwjgl3MixinPostProcessor implements IMixinConfigPlugin {
 			HAS_APPLET_132 = VersionPredicate.parse(">=1.3-alpha.12.18.a"); // 12w18a
 			NEW_CLIPBOARD = VersionPredicate.parse(">=1.2.4");
 			OLD_CLIPBOARD = VersionPredicate.parse(">=1.0.0-alpha.0.15"); // a1.0.15
-			AWT_LINK = VersionPredicate.parse(">=1.8-alpha.14.25.a"); // 14w28a
+			AWT_LINK = VersionPredicate.parse(">=1.8-alpha.14.25.a"); // 14w25a
 			MOUSE_COMPONENT_FIX = VersionPredicate.parse("<1.6-alpha.13.16.a"); // 13w16a
 			OLD_GAMERENDERER = VersionPredicate.parse("<=1.8.2-pre.2");
 			OLD_WINDOW_SCALE = VersionPredicate.parse("<1.3-alpha.12.21.a"); // 12w21a

--- a/src/main/java/io/github/moehreag/legacylwjgl3/Lwjgl3MixinPostProcessor.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/Lwjgl3MixinPostProcessor.java
@@ -31,7 +31,7 @@ import static io.github.moehreag.legacylwjgl3.LegacyLWJGL3.LOGGER;
 public class Lwjgl3MixinPostProcessor implements IMixinConfigPlugin {
 	private static final Version MINECRAFT_VERSION = FabricLoader.getInstance().getModContainer("minecraft").orElseThrow().getMetadata().getVersion();
 
-	private static final VersionPredicate SCREEN_UNAVAILABLE, HAS_APPLET, HAS_APPLET_132, NEW_CLIPBOARD, OLD_CLIPBOARD, MOUSE_COMPONENT_FIX,
+	private static final VersionPredicate SCREEN_UNAVAILABLE, HAS_APPLET, HAS_APPLET_132, NEW_CLIPBOARD, OLD_CLIPBOARD, AWT_LINK, MOUSE_COMPONENT_FIX,
 			OLD_GAMERENDERER, OLD_WINDOW_SCALE, OLD_EDITBOX, OLD_TEXTURE_MANGER, TEXTURE_MANAGER_1_5, PRE_BUFFERBUILDER, TESSELATOR_END_RETURN, NORETURN_TEXTRENDERER,
 			NONSTATIC_FILL, MULTIPLAYER_SCREEN_FIX_OLD, MULTIPLAYER_SCREEN_FIX, BOOK_EDIT_SCREEN_HANDLING, SIGN_EDIT_SCREEN_HANDLING;
 
@@ -42,6 +42,7 @@ public class Lwjgl3MixinPostProcessor implements IMixinConfigPlugin {
 			HAS_APPLET_132 = VersionPredicate.parse(">=1.3-alpha.12.18.a"); // 12w18a
 			NEW_CLIPBOARD = VersionPredicate.parse(">=1.2.4");
 			OLD_CLIPBOARD = VersionPredicate.parse(">=1.0.0-alpha.0.15"); // a1.0.15
+			AWT_LINK = VersionPredicate.parse(">=1.8-alpha.14.25.a"); // 14w28a
 			MOUSE_COMPONENT_FIX = VersionPredicate.parse("<1.6-alpha.13.16.a"); // 13w16a
 			OLD_GAMERENDERER = VersionPredicate.parse("<=1.8.2-pre.2");
 			OLD_WINDOW_SCALE = VersionPredicate.parse("<1.3-alpha.12.21.a"); // 12w21a
@@ -142,6 +143,9 @@ public class Lwjgl3MixinPostProcessor implements IMixinConfigPlugin {
 			additionalMixins.add("MixinScreenFixClipboard");
 		} else if (OLD_CLIPBOARD.test(MINECRAFT_VERSION)) {
 			additionalMixins.add("MixinScreenFixClipboardOld");
+		}
+		if (AWT_LINK.test(MINECRAFT_VERSION)) {
+			additionalMixins.add("MixinScreenFixOpenLink");
 		}
 		if (MOUSE_COMPONENT_FIX.test(MINECRAFT_VERSION)) {
 			additionalMixins.add("MouseMixin");

--- a/src/main/java/io/github/moehreag/legacylwjgl3/mixin/LegacyLWJGL3InternalMixin.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/mixin/LegacyLWJGL3InternalMixin.java
@@ -4,9 +4,11 @@ import java.util.Objects;
 
 import io.github.moehreag.legacylwjgl3.implementation.LegacyLWJGL3Internal;
 import io.github.moehreag.legacylwjgl3.util.IMEManager;
+import org.lwjgl.Sys;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.sdl.SDLClipboard;
+import org.lwjgl.sdl.SDLMisc;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
@@ -34,6 +36,19 @@ public abstract class LegacyLWJGL3InternalMixin {
 			SDLClipboard.SDL_SetClipboardText(s);
 		} else {
 			GLFW.glfwSetClipboardString(Display.getHandle(), s);
+		}
+	}
+
+	/**
+	 * @author rdh
+	 * @reason implement link opening
+	 */
+	@Overwrite
+	public static void openLink(String s) {
+		if (USE_SDL) {
+			SDLMisc.SDL_OpenURL(s);
+		} else {
+			Sys.openURL(s);
 		}
 	}
 

--- a/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixClipboard.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixClipboard.java
@@ -5,8 +5,6 @@ import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
-import java.net.URI;
-
 @SuppressWarnings({"UnusedMixin", "unused"})
 @Mixin(Screen.class)
 public abstract class MixinScreenFixClipboard {

--- a/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixClipboard.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixClipboard.java
@@ -29,12 +29,4 @@ public abstract class MixinScreenFixClipboard {
 		LegacyLWJGL3.setClipboard(string);
 	}
 
-	/**
-	 * @author rdh
-	 * @reason fix link opening with GLFW
-	 */
-	@Overwrite
-	public void openLink(URI uri) {
-		LegacyLWJGL3.openLink(uri.toString());
-	}
 }

--- a/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixClipboard.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixClipboard.java
@@ -5,6 +5,8 @@ import net.minecraft.client.gui.screen.Screen;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
+import java.net.URI;
+
 @SuppressWarnings({"UnusedMixin", "unused"})
 @Mixin(Screen.class)
 public abstract class MixinScreenFixClipboard {
@@ -25,5 +27,14 @@ public abstract class MixinScreenFixClipboard {
 	@Overwrite
 	public static void setClipboard(String string) {
 		LegacyLWJGL3.setClipboard(string);
+	}
+
+	/**
+	 * @author rdh
+	 * @reason fix link opening with GLFW
+	 */
+	@Overwrite
+	public void openLink(URI uri) {
+		LegacyLWJGL3.openLink(uri.toString());
 	}
 }

--- a/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixOpenLink.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/mixin/MixinScreenFixOpenLink.java
@@ -1,0 +1,22 @@
+package io.github.moehreag.legacylwjgl3.mixin;
+
+import io.github.moehreag.legacylwjgl3.LegacyLWJGL3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+import net.minecraft.client.gui.screen.Screen;
+
+import java.net.URI;
+
+@SuppressWarnings({"UnusedMixin", "unused"})
+@Mixin(Screen.class)
+public class MixinScreenFixOpenLink {
+	/**
+	 * @author rdh
+	 * @reason fix link opening with GLFW
+	 */
+	@Overwrite
+	public void openLink(URI uri) {
+		LegacyLWJGL3.openLink(uri.toString());
+	}
+}

--- a/src/main/java/org/lwjgl/opengl/SDLDisplay.java
+++ b/src/main/java/org/lwjgl/opengl/SDLDisplay.java
@@ -13,6 +13,7 @@ import io.github.moehreag.legacylwjgl3.SDLPlatforms;
 import io.github.moehreag.legacylwjgl3.implementation.LWJGLImplementationUtils;
 import io.github.moehreag.legacylwjgl3.implementation.sdl.SDLKeyboardImplementation;
 import io.github.moehreag.legacylwjgl3.implementation.sdl.SDLMouseImplementation;
+import io.github.moehreag.legacylwjgl3.util.OS;
 import lombok.Getter;
 import lombok.Setter;
 import net.fabricmc.loader.api.FabricLoader;
@@ -91,6 +92,10 @@ public final class SDLDisplay implements Display.Impl {
 		checkSdlError(SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_COPYRIGHT_STRING, "Minecraft EULA: https://minecraft.net/eula"));
 		checkSdlError(SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_TYPE_STRING, "game"));
 		checkSdlError(SDLHints.SDL_SetHint(SDLHints.SDL_HINT_IME_IMPLEMENTED_UI, "composition"));
+
+		if (OS.current() == OS.OSX) {
+			checkSdlError(SDLHints.SDL_SetHint(SDLHints.SDL_HINT_MAC_PRESS_AND_HOLD, "0"));
+		}
 
 		if (!SDL_Init(SDL_INIT_VIDEO)) {
 			throw new IllegalStateException("Unable to initialize SDL" + SDL_GetError());


### PR DESCRIPTION
- #32 set `java.awt.headless=true`; this broke opening links from clicking in game. added a redirect from AWT to `SDL_OpenURL` (SDL) or `Sys.openURL` (GLFW).
- holding down a key (for example, when moving) with SDL enabled would have the accent hints popup show, blocking ui elements; it now no longer does.