### PR TITLE
Implement framebuffer scaling on HiDPI display

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ environment variables.
 
 A list of currently available options is provided below.
 
-| Property Name                                 | Environment variable name                     | Description                                          |
-|-----------------------------------------------|-----------------------------------------------|------------------------------------------------------|
-| `legacy_lwjgl3.use_sdl`                       | `LEGACY_LWJGL3_USE_SDL`                       | Use SDL3 instead of GLFW for window & input handling |
+| Property Name                     | Environment variable name         | Default | Description                                           |
+|-----------------------------------|-----------------------------------|---------|-------------------------------------------------------|
+| `legacy_lwjgl3.use_sdl`           | `LEGACY_LWJGL3_USE_SDL`           | `false` | Use SDL3 instead of GLFW for window & input handling  |
+| `legacy_lwjgl3.scale_framebuffer` | `LEGACY_LWJGL3_SCALE_FRAMEBUFFER` | `true`  | Enable framebuffer scaling on HiDPI displays          |
 
 ### Unstable versions (CI)
 

--- a/common/src/main/java/io/github/moehreag/legacylwjgl3/LegacyLWJGL3.java
+++ b/common/src/main/java/io/github/moehreag/legacylwjgl3/LegacyLWJGL3.java
@@ -7,14 +7,26 @@ import org.slf4j.LoggerFactory;
 
 public class LegacyLWJGL3 implements ClientModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("LegacyLWJGL3");
-	public static final boolean USE_SDL = Boolean.getBoolean("legacy_lwjgl3.use_sdl") || System.getenv("LEGACY_LWJGL3_USE_SDL") != null;
-	public static final boolean SCALE_FRAMEBUFFER = Boolean.getBoolean("legacy_lwjgl3.scale_framebuffer") || System.getenv("LEGACY_LWJGL3_SCALE_FRAMEBUFFER") != null;
+	public static final boolean USE_SDL = readBooleanOption("legacy_lwjgl3.use_sdl", "LEGACY_LWJGL3_USE_SDL", false);
+	public static final boolean SCALE_FRAMEBUFFER = readBooleanOption("legacy_lwjgl3.scale_framebuffer", "LEGACY_LWJGL3_SCALE_FRAMEBUFFER", true);
 
 	@Override
 	public void onInitializeClient() {
 		if (USE_SDL) {
 			LOGGER.info("Using SDL3 for window & input handling instead of GLFW!");
 		}
+	}
+
+	private static boolean readBooleanOption(String propertyKey, String envVarName, boolean defaultValue) {
+		String property = System.getProperty(propertyKey);
+		if (property != null) {
+			return Boolean.parseBoolean(property);
+		}
+		if (System.getenv().containsKey(envVarName)) {
+			String envVar = System.getenv(envVarName);
+			return Boolean.parseBoolean(envVar) || "1".equals(envVar);
+		}
+		return defaultValue;
 	}
 
 	public static String getClipboard() {

--- a/common/src/main/java/io/github/moehreag/legacylwjgl3/LegacyLWJGL3.java
+++ b/common/src/main/java/io/github/moehreag/legacylwjgl3/LegacyLWJGL3.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 public class LegacyLWJGL3 implements ClientModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger("LegacyLWJGL3");
 	public static final boolean USE_SDL = Boolean.getBoolean("legacy_lwjgl3.use_sdl") || System.getenv("LEGACY_LWJGL3_USE_SDL") != null;
+	public static final boolean SCALE_FRAMEBUFFER = Boolean.getBoolean("legacy_lwjgl3.scale_framebuffer") || System.getenv("LEGACY_LWJGL3_SCALE_FRAMEBUFFER") != null;
 
 	@Override
 	public void onInitializeClient() {

--- a/src/main/java/io/github/moehreag/legacylwjgl3/implementation/glfw/GLFWMouseImplementation.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/implementation/glfw/GLFWMouseImplementation.java
@@ -43,8 +43,11 @@ public class GLFWMouseImplementation implements MouseImplementation {
                 button_states[button] = state;
         });
         this.posCallback = GLFWCursorPosCallback.create((window, xpos, ypos) -> {
-            int x = (int) (xpos);
-            int y = (int) (Display.getHeight() - ypos); // I don't know why but this un-inverts the y motion of mouse inputs
+            float scale = Display.getPixelScaleFactor();
+            int x = (int) (xpos * scale);
+            // LWJGL2: (0, 0) = the bottom-left corner
+            // GLFW: (0, 0) = the top-left corner
+            int y = (int) ((Display.getScreenHeight() - ypos) * scale);
             double dx = x - last_x;
             double dy = y - last_y;
             if (dx != 0 || dy != 0) {
@@ -120,16 +123,17 @@ public class GLFWMouseImplementation implements MouseImplementation {
 
     @Override
     public void setCursorPosition(double x, double y) {
+        float scale = Display.getPixelScaleFactor();
         this.last_x = x;
         this.last_y = y;
-        GLFW.glfwSetCursorPos(this.windowHandle, x, y);
+        GLFW.glfwSetCursorPos(this.windowHandle, x / scale, y / scale);
     }
 
     @Override
     public void grabMouse(boolean grab) {
         GLFW.glfwSetInputMode(this.windowHandle, GLFW.GLFW_CURSOR, grab ? GLFW.GLFW_CURSOR_DISABLED : GLFW.GLFW_CURSOR_NORMAL);
         if (!grab) {
-            GLFW.glfwSetCursorPos(this.windowHandle, last_x, last_y);
+            setCursorPosition(last_x, last_y);
         }
         this.grabbed = grab;
         this.reset();

--- a/src/main/java/io/github/moehreag/legacylwjgl3/implementation/sdl/SDLMouseImplementation.java
+++ b/src/main/java/io/github/moehreag/legacylwjgl3/implementation/sdl/SDLMouseImplementation.java
@@ -87,15 +87,16 @@ public class SDLMouseImplementation implements MouseImplementation {
 
 	@Override
 	public void setCursorPosition(double x, double y) {
+		float scale = Display.getPixelScaleFactor();
 		this.last_x = x;
 		this.last_y = y;
-		SDL_WarpMouseInWindow(windowHandle, (float) x, (float) y);
+		SDL_WarpMouseInWindow(windowHandle, (float) (x / scale), (float) (y / scale));
 	}
 
 	@Override
 	public void grabMouse(boolean grab) {
 		if (!grab) {
-			SDL_WarpMouseInWindow(windowHandle, (float) last_x, (float) last_y);
+			setCursorPosition(last_x, last_y);
 		}
 		SDL_SetWindowRelativeMouseMode(windowHandle, grab);
 		this.grabbed = grab;
@@ -138,8 +139,11 @@ public class SDLMouseImplementation implements MouseImplementation {
 
 			}
 			case SDL_EVENT_MOUSE_MOTION -> {
-				int x = (int) (mouseMotionEvent.x());
-				int y = (int) (Display.getHeight() - mouseMotionEvent.y());
+				float scale = Display.getPixelScaleFactor();
+				int x = (int) (mouseMotionEvent.x() * scale);
+				// LWJGL2: (0, 0) = the bottom-left corner
+				// SDL3: (0, 0) = the top-left corner
+				int y = (int) ((Display.getScreenHeight() - mouseMotionEvent.y()) * scale);
 				double dx = mouseMotionEvent.xrel();
 				double dy = -mouseMotionEvent.yrel();
 				if (dx != 0 || dy != 0) {

--- a/src/main/java/org/lwjgl/opengl/Display.java
+++ b/src/main/java/org/lwjgl/opengl/Display.java
@@ -153,6 +153,10 @@ public class Display {
 		impl.swapBuffers();
 	}
 
+	public static float getPixelScaleFactor() {
+		return impl.getPixelScaleFactor();
+	}
+
 	sealed interface Impl permits SDLDisplay, GLFWDisplay {
 		long getHandle();
 
@@ -219,5 +223,7 @@ public class Display {
 		void swapBuffers();
 
 		boolean isCloseRequested();
+
+		float getPixelScaleFactor();
 	}
 }

--- a/src/main/java/org/lwjgl/opengl/GLFWDisplay.java
+++ b/src/main/java/org/lwjgl/opengl/GLFWDisplay.java
@@ -40,6 +40,7 @@ public final class GLFWDisplay implements Display.Impl {
 	@Getter
 	private int y;
 	private int windowedY;
+	private float scale;
 	private boolean window_resized = true;
 	private boolean minimized;
 	@Getter
@@ -114,6 +115,10 @@ public final class GLFWDisplay implements Display.Impl {
 
 	public int getScreenHeight() {
 		return height;
+	}
+
+	public float getPixelScaleFactor() {
+		return scale;
 	}
 
 	@Nullable
@@ -194,7 +199,7 @@ public final class GLFWDisplay implements Display.Impl {
 			GLFW.glfwWindowHint(GLFW.GLFW_CONTEXT_VERSION_MINOR, 2);
 			GLFW.glfwWindowHint(GLFW.GLFW_OPENGL_PROFILE, GLFW.GLFW_OPENGL_COMPAT_PROFILE);
 		}
-		GLFW.glfwWindowHint(GLFW.GLFW_SCALE_FRAMEBUFFER, 0);
+		GLFW.glfwWindowHint(GLFW.GLFW_SCALE_FRAMEBUFFER, LegacyLWJGL3.SCALE_FRAMEBUFFER ? GLFW.GLFW_TRUE : GLFW.GLFW_FALSE);
 		GLFW.glfwWindowHint(GLFW.GLFW_ALPHA_BITS, pixelFormat.getAlphaBits());
 		GLFW.glfwWindowHint(GLFW.GLFW_DEPTH_BITS, pixelFormat.getDepthBits());
 		GLFW.glfwWindowHint(GLFW.GLFW_STENCIL_BITS, pixelFormat.getStencilBits());
@@ -230,9 +235,10 @@ public final class GLFWDisplay implements Display.Impl {
 		GLFW.glfwGetWindowSize(handle, xBox, yBox);
 		framebufferWidth = xBox[0] <= 0 ? 1 : xBox[0];
 		framebufferHeight = yBox[0] <= 0 ? 1 : yBox[0];
+		updateScaleFactor();
 
 		// create general callbacks
-		GLFW.glfwSetWindowSizeCallback(handle, GLFWWindowSizeCallback.create(this::resizeCallback));
+		GLFW.glfwSetWindowSizeCallback(handle, GLFWWindowSizeCallback.create(this::onWindowResize));
 		GLFW.glfwSetFramebufferSizeCallback(handle, GLFWFramebufferSizeCallback.create(this::onFramebufferResize));
 		GLFW.glfwSetWindowFocusCallback(handle, (window, focused1) -> {
 			if (window == handle) {
@@ -279,6 +285,7 @@ public final class GLFWDisplay implements Display.Impl {
 			if (this.framebufferWidth != prevWidth || this.framebufferHeight != prevHeight) {
 				window_resized = true;
 			}
+			this.updateScaleFactor();
 		} else {
 			minimized = true;
 		}
@@ -447,11 +454,20 @@ public final class GLFWDisplay implements Display.Impl {
 		return !minimized;
 	}
 
-	private void resizeCallback(long window, int width, int height) {
+	private void onWindowResize(long window, int width, int height) {
 		if (window == handle) {
 			window_resized = true;
 			this.width = width;
 			this.height = height;
+			this.updateScaleFactor();
+		}
+	}
+
+	private void updateScaleFactor() {
+		if (framebufferHeight != 0 && framebufferWidth != 0 && width != 0 && height != 0) {
+			float xscale = framebufferWidth * 1.0f / width;
+			float yscale = framebufferHeight * 1.0f / height;
+			this.scale = Math.max(xscale, yscale);
 		}
 	}
 

--- a/src/main/java/org/lwjgl/opengl/SDLDisplay.java
+++ b/src/main/java/org/lwjgl/opengl/SDLDisplay.java
@@ -165,6 +165,10 @@ public final class SDLDisplay implements Display.Impl {
 		return height;
 	}
 
+	public float getPixelScaleFactor() {
+		return SDL_GetWindowPixelDensity(handle);
+	}
+
 	@Nullable
 	public DisplayMode getDesktopDisplayMode() {
 		var mode = SDL_GetDesktopDisplayMode(SDL_GetPrimaryDisplay());
@@ -315,6 +319,7 @@ public final class SDLDisplay implements Display.Impl {
 
 		checkSdlError(SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIDDEN_BOOLEAN, true));
 		checkSdlError(SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_RESIZABLE_BOOLEAN, resizable));
+		checkSdlError(SDL_SetBooleanProperty(props, SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN, LegacyLWJGL3.SCALE_FRAMEBUFFER));
 		handle = checkSdlError(SDL_CreateWindowWithProperties(props));
 		SDL_DestroyProperties(props);
 


### PR DESCRIPTION
Previously, on HiDPI displays, the game appeared blurry when using this mod, either on GLFW or on SDL. This PR adds a new option (controlled by the system property `legacy_lwjgl3.scale_framebuffer` or the envvar `LEGACY_LWJGL3_SCALE_FRAMEBUFFER`) that controls the framebuffer scaling behavior. This option is enabled by default to match vanilla behavior in modern versions. This option controls different flags depending on the underlying platform:

- GLFW: `GLFW_SCALE_FRAMEBUFFER`
- SDL: `SDL_PROP_WINDOW_CREATE_HIGH_PIXEL_DENSITY_BOOLEAN`

This PR also implements `Display#getPixelScaleFactor` which returns the current scaling factor.

Tested on Wayland with 150% scaling.